### PR TITLE
fix: locale instances not actually being created

### DIFF
--- a/shared/locale.lua
+++ b/shared/locale.lua
@@ -28,10 +28,11 @@ local function translateKey(phrase, subs)
 end
 
 --- Constructor function for a new Locale class instance
+--- @param _ unknown  kept for backwards compatibility
 --- @param opts table<string, any> - Constructor opts param
 --- @return Locale
-function Locale:new(opts)
-    setmetatable(self, Locale)
+function Locale.new(_, opts)
+    local self = setmetatable({}, Locale)
 
     self.fallback = opts.fallbackLang and Locale.new({}, {
         warnOnMissing = false,


### PR DESCRIPTION
## Description

Fix Locale instances not actually being created.

After qbcore-framework/qb-core#693, calling `Locale:new` would not actually create a new table for the Locale instance but instead use the already existing `Locale` variable itself, which would result in running the following code:
```lua
setmetatable(Locale, Locale)
```

This would cause an error when trying to index the table with keys that don't exist in `Locale`.
![unknown](https://user-images.githubusercontent.com/43699941/193429477-7a1933c8-d480-4cea-acf2-84ecfb8866ba.png)

With the intended way that `Locale` is used, this PR should work fine and be backwards compatible.

## Checklist

<!-- Put an x inside the [ ] to check an item, like so: [x] -->

- [x] I have personally loaded this code into an updated qbcore project and checked all of its functionality.
- [x] My code fits the style guidelines.
- [x] My PR fits the contribution guidelines.
